### PR TITLE
ci(workflow): update release workflow

### DIFF
--- a/.github/workflows/sync-figma-tokens.yml
+++ b/.github/workflows/sync-figma-tokens.yml
@@ -59,7 +59,7 @@ jobs:
         uses: peter-evans/create-pull-request@v6
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          commit-message: 'chore: update Figma design tokens'
+          commit-message: 'chore(design-tokens): update Figma design tokens'
           title: 'chore: Update Figma design tokens'
           body: |
             ## Automated Figma Token Update

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -7,7 +7,15 @@
     }
   ],
   "plugins": [
-    "@semantic-release/commit-analyzer",
+    [
+      "@semantic-release/commit-analyzer",
+      {
+        "releaseRules": [
+          { "type": "chore", "scope": "tokens", "release": "patch" },
+          { "type": "chore", "scope": "design-tokens", "release": "patch" }
+        ]
+      }
+    ],
     "@semantic-release/release-notes-generator",
     [
       "@semantic-release/changelog",


### PR DESCRIPTION
Update the release workflow to allow chore(design-tokens) updates to create new release package with the new tokens when they have been updated