### PR TITLE
ci(workflows): amend node version

### DIFF
--- a/.github/workflows/release-package.yml
+++ b/.github/workflows/release-package.yml
@@ -23,12 +23,12 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
+      - name: Setup Node
+        uses: actions/setup-node@v6.1.0
         with:
-          node-version: '22'
+          node-version-file: '.nvmrc'
           cache: 'npm'
-          registry-url: 'https://registry.npmjs.org'
+          registry-url: 'https://npm.pkg.github.com'
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/sync-figma-tokens.yml
+++ b/.github/workflows/sync-figma-tokens.yml
@@ -16,10 +16,10 @@ jobs:
         with:
           ref: master
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
+      - name: Setup Node
+        uses: actions/setup-node@v6.1.0
         with:
-          node-version: '18'
+          node-version-file: '.nvmrc'
           cache: 'npm'
 
       - name: Install dependencies


### PR DESCRIPTION
Use the .nvmrc node version in the release and synch tokens workflows