### PR TITLE
ci(dependabot): update per security hardening recommendations

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: 'npm'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+    cooldown:
+      default: 5

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,2 @@
 save-exact=true
+min-release-age=5


### PR DESCRIPTION
- Set Dependabot to have the cooldown property set to 5
- Set .npmrc to have min-release-age set to 5